### PR TITLE
feat: informing when logger is called for an error event

### DIFF
--- a/superdebug-server.js
+++ b/superdebug-server.js
@@ -67,8 +67,8 @@ function handleResponse (request, start, logger, debugLog, debugCurl, isError) {
     var status = isError ? 'NO_STATUS_CODE' : responseOrError.status
 
     debugCurl(chalk.gray(curl))
-    logger(curl)
-    if (isError) logger(chalk.red(responseOrError))
+    logger(curl, isError)
+    if (isError) logger(chalk.red(responseOrError), isError)
     debugLog(
       '%s %s %s %s %s',
       chalk.magenta(protocol),
@@ -77,7 +77,7 @@ function handleResponse (request, start, logger, debugLog, debugCurl, isError) {
       chalk.gray(request.url),
       chalk.gray('(') + chalk[getColorByResponseTime(elapsed)](elapseTime) + chalk.gray(')')
     )
-    logger(protocol + ' ' + requestMethod + ' ' + status + ' ' + request.url + ' (' + elapseTime + ')')
+    logger(protocol + ' ' + requestMethod + ' ' + status + ' ' + request.url + ' (' + elapseTime + ')', isError)
   }
 };
 


### PR DESCRIPTION
When an error occurs, logger is called more than once to log curl, which may be an undesirable behavior if the curl log is used for metrics, as it can pass the impression of duplicated requests.

The solution here is to pass to the logger the isError variable, so it can decide what to do with it